### PR TITLE
feat: Support multiple NFT contracts on backend calls

### DIFF
--- a/src/config/constants/bills.ts
+++ b/src/config/constants/bills.ts
@@ -18,6 +18,62 @@ const bills: BillsConfig[] = [
     twitter: 'https://twitter.com/ape_swap',
   },
   {
+    index: 14,
+    contractAddress: {
+      [CHAIN_ID.BSC_TESTNET]: '',
+      [CHAIN_ID.BSC]: '0xf297F71f4664cF7F1Cd5d90720967998A1163cC3',
+    },
+    billType: 'BANANA Bill',
+    token: tokens.busd,
+    quoteToken: tokens.wbnb,
+    lpToken: tokens.bnbBusd,
+    earnToken: tokens.banana,
+    projectLink: 'https://apeswap.finance/',
+    twitter: 'https://twitter.com/ape_swap',
+  },
+  {
+    index: 15,
+    contractAddress: {
+      [CHAIN_ID.BSC_TESTNET]: '',
+      [CHAIN_ID.BSC]: '0x937A30Fd88f48B23DeABf4fD43c42cc9d3f3F9Dd',
+    },
+    billType: 'BANANA Bill',
+    token: tokens.busd,
+    quoteToken: tokens.usdc,
+    lpToken: tokens.usdcBusd,
+    earnToken: tokens.banana,
+    projectLink: 'https://apeswap.finance/',
+    twitter: 'https://twitter.com/ape_swap',
+  },
+  {
+    index: 16,
+    contractAddress: {
+      [CHAIN_ID.BSC_TESTNET]: '',
+      [CHAIN_ID.BSC]: '0x2D375a67366eDFB92F520aE428E8E08451D638d2',
+    },
+    billType: 'BANANA Bill',
+    token: tokens.eth,
+    quoteToken: tokens.wbnb,
+    lpToken: tokens.bnbEth,
+    earnToken: tokens.banana,
+    projectLink: 'https://apeswap.finance/',
+    twitter: 'https://twitter.com/ape_swap',
+  },
+  {
+    index: 17,
+    contractAddress: {
+      [CHAIN_ID.BSC_TESTNET]: '',
+      [CHAIN_ID.BSC]: '0x44921f493887ab8a8b9db54db335f65c1ef8d51a',
+    },
+    billType: 'BANANA Bill',
+    token: tokens.btc,
+    quoteToken: tokens.wbnb,
+    lpToken: tokens.bnbBtc,
+    earnToken: tokens.banana,
+    projectLink: 'https://apeswap.finance/',
+    twitter: 'https://twitter.com/ape_swap',
+  },
+  {
     index: 12,
     contractAddress: {
       [CHAIN_ID.BSC_TESTNET]: '',
@@ -143,6 +199,7 @@ const bills: BillsConfig[] = [
     earnToken: tokens.banana,
     projectLink: 'https://apeswap.finance/',
     twitter: 'https://twitter.com/ape_swap',
+    inactive: true,
   },
   {
     index: 1,
@@ -157,6 +214,7 @@ const bills: BillsConfig[] = [
     earnToken: tokens.banana,
     projectLink: 'https://apeswap.finance/',
     twitter: 'https://twitter.com/ape_swap',
+    inactive: true,
   },
   {
     index: 2,
@@ -171,6 +229,7 @@ const bills: BillsConfig[] = [
     earnToken: tokens.banana,
     projectLink: 'https://apeswap.finance/',
     twitter: 'https://twitter.com/ape_swap',
+    inactive: true,
   },
   {
     index: 3,
@@ -185,6 +244,7 @@ const bills: BillsConfig[] = [
     earnToken: tokens.banana,
     projectLink: 'https://apeswap.finance/',
     twitter: 'https://twitter.com/ape_swap',
+    inactive: true,
   },
   {
     index: 4,
@@ -199,6 +259,7 @@ const bills: BillsConfig[] = [
     earnToken: tokens.banana,
     projectLink: 'https://apeswap.finance/',
     twitter: 'https://twitter.com/ape_swap',
+    inactive: true,
   },
 ]
 

--- a/src/config/constants/bills.ts
+++ b/src/config/constants/bills.ts
@@ -4,6 +4,20 @@ import { BillsConfig } from './types'
 
 const bills: BillsConfig[] = [
   {
+    index: 13,
+    contractAddress: {
+      [CHAIN_ID.BSC_TESTNET]: '',
+      [CHAIN_ID.BSC]: '0xE325439439D692DC858Ba887601999D57d35688F',
+    },
+    billType: 'BANANA Bill',
+    token: tokens.banana,
+    quoteToken: tokens.wbnb,
+    lpToken: tokens.bananaBnb,
+    earnToken: tokens.banana,
+    projectLink: 'https://apeswap.finance/',
+    twitter: 'https://twitter.com/ape_swap',
+  },
+  {
     index: 12,
     contractAddress: {
       [CHAIN_ID.BSC_TESTNET]: '',

--- a/src/state/bills/fetchBillsUser.ts
+++ b/src/state/bills/fetchBillsUser.ts
@@ -31,9 +31,9 @@ export const fetchUserBalances = async (chainId: number, account) => {
   return tokenBalances
 }
 
-export const fetchUserOwnedBillNftData = async (ids: string[]) => {
-  const billNftData = ids?.map(async (id) => {
-    return { id, data: await getBillNftData(id) }
+export const fetchUserOwnedBillNftData = async (ownedBillsData: { id: string; billNftAddress: string }[]) => {
+  const billNftData = ownedBillsData?.map(async ({ id, billNftAddress }) => {
+    return { id, data: await getBillNftData(id, billNftAddress) }
   })
   return Promise.all(billNftData)
 }
@@ -52,6 +52,7 @@ export const fetchUserOwnedBills = async (chainId: number, account: string): Pro
       (id: BigNumber) =>
         id.gt(0) &&
         (billDataCalls.push({ address: bills[index].contractAddress[chainId], name: 'billInfo', params: [id] }),
+        billDataCalls.push({ address: bills[index].contractAddress[chainId], name: 'billNft' }),
         billsPendingRewardCall.push({
           address: bills[index].contractAddress[chainId],
           name: 'pendingPayoutFor',
@@ -62,15 +63,22 @@ export const fetchUserOwnedBills = async (chainId: number, account: string): Pro
   const billData = await multicall(chainId, billAbi, billDataCalls)
   const pendingRewardsCall = await multicall(chainId, billAbi, billsPendingRewardCall)
 
-  return billDataCalls.map((b, index) => {
-    return {
-      address: b.address,
-      id: b.params[0].toString(),
-      payout: billData[index][0].toString(),
-      vesting: billData[index][1].toString(),
-      lastBlockTimestamp: billData[index][2].toString(),
-      truePricePaid: billData[index][3].toString(),
-      pendingRewards: pendingRewardsCall[index][0].toString(),
+  const result = []
+
+  for (let i = 0; i < billsPendingRewardCall.length; i++) {
+    const billDataPos = i === 0 ? 0 : i * 2
+    const data = {
+      address: billsPendingRewardCall[i].address,
+      id: billsPendingRewardCall[i].params[0].toString(),
+      payout: billData[billDataPos][0].toString(),
+      billNftAddress: billData[billDataPos + 1][0].toString(),
+      vesting: billData[billDataPos][1].toString(),
+      lastBlockTimestamp: billData[billDataPos][2].toString(),
+      truePricePaid: billData[billDataPos][3].toString(),
+      pendingRewards: pendingRewardsCall[i][0].toString(),
     }
-  })
+    result.push(data)
+  }
+
+  return result
 }

--- a/src/state/bills/getBillNftData.ts
+++ b/src/state/bills/getBillNftData.ts
@@ -2,13 +2,13 @@ import { apiBaseUrl } from 'hooks/api'
 import axiosRetry from 'axios-retry'
 import axios from 'axios'
 
-const getBillNftData = async (billNftId: string) => {
+const getBillNftData = async (billNftId: string, billNftAddress: string) => {
   try {
     axiosRetry(axios, {
       retries: 5,
       retryCondition: () => true,
     })
-    const response = await axios.get(`${apiBaseUrl}/bills/bsc/${billNftId}`)
+    const response = await axios.get(`${apiBaseUrl}/bills/bsc/${billNftAddress}/${billNftId}`)
     const billNftDataResp = await response.data
     if (billNftDataResp.statusCode === 500) {
       return null
@@ -18,7 +18,9 @@ const getBillNftData = async (billNftId: string) => {
     return null
   }
 }
-
+/**
+ * @deprecated API doesn't support it any more and its not used
+ */
 export const getNewBillNftData = async (billNftId: string, transactionHash: string) => {
   try {
     axiosRetry(axios, {

--- a/src/state/bills/index.ts
+++ b/src/state/bills/index.ts
@@ -116,12 +116,12 @@ export const fetchUserOwnedBillsDataAsync =
       dispatch(setUserOwnedBillsData(userOwnedBillsData))
 
       // Fetch owned bill NFT data
-      const ownedBillIds = mapUserOwnedBills.flatMap((bs) => {
+      const ownedBillsData = mapUserOwnedBills.flatMap((bs) => {
         return bs.map((b) => {
-          return b.id
+          return { id: b.id, billNftAddress: b.billNftAddress }
         })
       })
-      const userBillNftData = await fetchUserOwnedBillNftData(ownedBillIds)
+      const userBillNftData = await fetchUserOwnedBillNftData(ownedBillsData)
       const ownedBillsWithNftData = mapUserOwnedBills.map((bs, index) => {
         return {
           index: bills[index].index,
@@ -152,6 +152,9 @@ export const updateUserBalance =
     dispatch(updateBillsUserData({ index, field: 'stakingTokenBalance', value: tokenBalances[index] }))
   }
 
+/**
+ * @deprecated since multiple NFT contracts
+ */
 export const updateUserNftData =
   (index: number, billNftId: string, transactionHash: string): AppThunk =>
   async (dispatch) => {

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -110,6 +110,7 @@ export interface UserBill {
   truePricePaid: string
   lastBlockTimestamp: string
   pendingRewards: string
+  billNftAddress: string
   nftData?: UserBillNft
 }
 


### PR DESCRIPTION
In this PR a get the billNft contract address from the `CustomBill` contract and use it to make the adequate call to the backend and load the data.