### PR TITLE
feat: ApeStats Masterchef & Maximizers V2

### DIFF
--- a/src/components/MigrationRequiredPopup/index.tsx
+++ b/src/components/MigrationRequiredPopup/index.tsx
@@ -17,11 +17,13 @@ const MigrationRequiredPopup = ({
   farms,
   vaults,
   homepage,
+  hasPositionsToMigrate,
 }: {
   v2Farms: Farm[]
   farms: Farm[]
   vaults: Vault[]
   homepage?: boolean
+  hasPositionsToMigrate?: boolean
 }) => {
   const { chainId } = useActiveWeb3React()
   const { t } = useTranslation()
@@ -59,6 +61,7 @@ const MigrationRequiredPopup = ({
   })
 
   const userHasFarmOrVault =
+    hasPositionsToMigrate ||
     [...filteredFarms, ...filterV1Dust].filter((product) => new BigNumber(product?.userData?.stakedBalance).gt(0))
       ?.length > 0
 

--- a/src/state/statsPage/types.ts
+++ b/src/state/statsPage/types.ts
@@ -14,6 +14,7 @@ export interface ApiResponse {
       totalWalletHoldings: number
     }
   }
+  hasPositionsToMigrate: boolean
 }
 
 export interface IAssetBreakdown {

--- a/src/views/Stats/Stats.tsx
+++ b/src/views/Stats/Stats.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource theme-ui */
 import React, { useState } from 'react'
-import { Text } from '@ape.swap/uikit'
+import { Flex, Text } from '@ape.swap/uikit'
 import { Select, SelectItem } from '@apeswapfinance/uikit'
 
 import { useTranslation } from 'contexts/Localization'
@@ -99,10 +99,10 @@ const Stats: React.FC = () => {
         <StatsContent>
           {!account ? (
             <>
-              <div style={{ marginBottom: '144px' }}>
-                <Text sx={{ margin: '128px 0 16px 0', textTransform: 'uppercase' }}>{t('You are not connected')}</Text>
+              <Flex sx={{ flexDirection: 'column', margin: '128px 0', gap: '16px' }}>
+                <Text sx={{ textTransform: 'uppercase' }}>{t('You are not connected')}</Text>
                 <ConnectButton />
-              </div>
+              </Flex>
             </>
           ) : loading ? (
             <PageLoader />

--- a/src/views/Stats/Stats.tsx
+++ b/src/views/Stats/Stats.tsx
@@ -80,7 +80,7 @@ const Stats: React.FC = () => {
             {displayChainOptions.map((option) => {
               return (
                 <SelectItem key={option.label} value={option.value} size="sm">
-                  <Text size="12px" fontWeight={500}>
+                  <Text size="12px" fontWeight={500} style={{ lineHeight: 1.5 }}>
                     {t(option.label)}
                   </Text>
                 </SelectItem>

--- a/src/views/Stats/Stats.tsx
+++ b/src/views/Stats/Stats.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource theme-ui */
 import React, { useState } from 'react'
-import { Flex, Text } from '@ape.swap/uikit'
+import { Text } from '@ape.swap/uikit'
 import { Select, SelectItem } from '@apeswapfinance/uikit'
 
 import { useTranslation } from 'contexts/Localization'
@@ -95,29 +95,7 @@ const Stats: React.FC = () => {
 
       <Page width="1220px">
         <TabNavStats activeTab={activeTab} onChangeActiveTab={handleChangeActiveTab} />
-        <Flex
-          sx={{
-            background: 'white3',
-            marginTop: '20px',
-            padding: '30px',
-            borderRadius: '10px',
-            flexDirection: 'column',
-            alignItems: 'center',
-            textAlign: 'center',
-            justifyContent: 'center',
-            border: '3px solid',
-            borderColor: 'yellow',
-          }}
-        >
-          <Text size="26px" weight={700}>
-            {t('Attention!')}
-          </Text>
-          <Text sx={{ mt: '20px' }}>
-            {t(
-              'Assets staked in MasterApeV2 will not be included in your ApeStats data until the next update. Thanks for your patience!',
-            )}
-          </Text>
-        </Flex>
+
         <StatsContent>
           {!account ? (
             <>

--- a/src/views/Stats/Stats.tsx
+++ b/src/views/Stats/Stats.tsx
@@ -19,6 +19,7 @@ import PageLoader from '../../components/PageLoader'
 import { BannerStats } from './components/BannerStats'
 import { TabOption, TabNavStats } from './components/TabNavStats'
 import { ShareButton } from './components/ShareButton'
+import MigrationRequiredPopup from 'components/MigrationRequiredPopup'
 
 import { Pacoca, PacocaCard, StatsContent, StyledFlex, TopContent } from './styles'
 import { Flex, Text } from '@ape.swap/uikit'
@@ -46,7 +47,7 @@ const Stats: React.FC = () => {
   const { t } = useTranslation()
   const isMobile = useIsMobile()
   const { account } = useActiveWeb3React()
-  const { selectedChain, handleChangeSelectedChain, loading } = useStats()
+  const { selectedChain, handleChangeSelectedChain, loading, stats } = useStats()
   const [activeTab, setActiveTab] = useState<TabOption>(TabOption.ANALYTICS)
 
   const tabMenuMap = {
@@ -61,6 +62,12 @@ const Stats: React.FC = () => {
 
   return (
     <>
+      <MigrationRequiredPopup
+        v2Farms={[]}
+        farms={[]}
+        vaults={[]}
+        hasPositionsToMigrate={stats?.hasPositionsToMigrate}
+      />
       <TopContent>
         <StyledFlex loading={loading}>
           <Select

--- a/src/views/Stats/Stats.tsx
+++ b/src/views/Stats/Stats.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource theme-ui */
 import React, { useState } from 'react'
+import { Flex, Text } from '@ape.swap/uikit'
 import { Select, SelectItem } from '@apeswapfinance/uikit'
 
 import { useTranslation } from 'contexts/Localization'
@@ -22,7 +23,6 @@ import { ShareButton } from './components/ShareButton'
 import MigrationRequiredPopup from 'components/MigrationRequiredPopup'
 
 import { Pacoca, PacocaCard, StatsContent, StyledFlex, TopContent } from './styles'
-import { Flex, Text } from '@ape.swap/uikit'
 
 const displayChainOptions = [
   {

--- a/src/views/Stats/Stats.tsx
+++ b/src/views/Stats/Stats.tsx
@@ -17,7 +17,7 @@ import Analytics from './components/Analytics'
 import Portfolio from './components/Portfolio'
 import PageLoader from '../../components/PageLoader'
 import { BannerStats } from './components/BannerStats'
-import { TabNavStats } from './components/TabNavStats'
+import { TabOption, TabNavStats } from './components/TabNavStats'
 import { ShareButton } from './components/ShareButton'
 
 import { Pacoca, PacocaCard, StatsContent, StyledFlex, TopContent } from './styles'
@@ -47,7 +47,7 @@ const Stats: React.FC = () => {
   const isMobile = useIsMobile()
   const { account } = useActiveWeb3React()
   const { selectedChain, handleChangeSelectedChain, loading } = useStats()
-  const [activeTab, setActiveTab] = useState('Analytics')
+  const [activeTab, setActiveTab] = useState<TabOption>(TabOption.ANALYTICS)
 
   const tabMenuMap = {
     Portfolio: <Portfolio />,
@@ -55,7 +55,7 @@ const Stats: React.FC = () => {
     NFT: <NFT />,
   }
 
-  const handleChangeActiveTab = (tab: string) => {
+  const handleChangeActiveTab = (tab: TabOption) => {
     setActiveTab(tab)
   }
 

--- a/src/views/Stats/components/TabNavStats/index.tsx
+++ b/src/views/Stats/components/TabNavStats/index.tsx
@@ -3,17 +3,23 @@ import { Bar, Container, Indicator, StyledTabNavStats, Tab } from './styles'
 
 interface TabNavProps {
   activeTab: string
-  onChangeActiveTab: (tab: string) => void
+  onChangeActiveTab: (tab: TabOption) => void
 }
 
-const tabOptions = ['Portfolio', 'Analytics', 'NFT']
+export enum TabOption {
+  PORTFOLIO = 'Portfolio',
+  ANALYTICS = 'Analytics',
+  NFT = 'NFT',
+}
+
+const tabOptions = Object.values(TabOption)
 
 export const TabNavStats: React.FC<TabNavProps> = ({ activeTab, onChangeActiveTab }) => {
   const [width, setWidth] = useState(0)
   const [left, setLeft] = useState(0)
   const refs = useRef([])
 
-  const handleActiveTab = (el: HTMLDivElement, tab: string) => {
+  const handleActiveTab = (el: HTMLDivElement, tab: TabOption) => {
     setLeft(el.offsetLeft)
     setWidth(el.offsetWidth)
 

--- a/src/views/Stats/styles.ts
+++ b/src/views/Stats/styles.ts
@@ -89,7 +89,6 @@ export const PacocaCard = styled(Link)`
 
   padding: 16px 32px;
   margin: 0 auto !important;
-  max-width: 260px;
 
   background: ${({ theme }) => theme.colors.white2};
   border-radius: 10px;


### PR DESCRIPTION
## CHANGES
- API now returns Masterchef & Maximizers V2 positions info.
- Farm APRs now have LP APR included.
- API will no longer return Masterchef & Maximizers V1 positions info.
- Return new prop `hasPositionsToMigrate` that indicates if the user has active legacy farms/vaults positions to migrate.
- Add `Migration Popup` on Stats Page.
- Fix some UI issues.
- Refactor code to improve readability.